### PR TITLE
fix: Added pending_documents to trigger SDK

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -85,7 +85,6 @@ function Home() {
     // pending_step_up is the correct status trigger the SDK
     // some legacy implentations will contain pending documents
     const journeyStatus = jsonResponse.status.toLowerCase();
-
     if (journeyStatus === "pending_step_up" || journeyStatus === "pending_documents") {
       router.push(`/${jsonResponse.journey_application_token}`);
     } else if (journeyStatus === "completed") {


### PR DESCRIPTION
The objective of this PR is to add pending_documents journey state to give backward compatibility with initial journeys using  DOCV nodes.