### PR TITLE
default to undefined instead of empty string

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,18 +31,18 @@ const StyledAnchor = styled("a", {
 });
 
 function Home() {
-  const [birthDate, setbirthDate] = useState("");
-  const [addressLine1, setAddressLine1] = useState("");
-  const [phoneNumber, setPhoneNumber] = useState("");
-  const [addressCity, setAddressCity] = useState("");
-  const [addressState, setAddressState] = useState("NY");
-  const [addressPostalCode, setAddressPostalCode] = useState("");
-  const [income, setIncome] = useState("");
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [email, setEmail] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [ssn, setSSN] = useState("");
+  const [birthDate, setbirthDate] = useState<string>();
+  const [addressLine1, setAddressLine1] = useState<string>();
+  const [phoneNumber, setPhoneNumber] = useState<string>();
+  const [addressCity, setAddressCity] = useState<string>();
+  const [addressState, setAddressState] = useState<string>("NY");
+  const [addressPostalCode, setAddressPostalCode] = useState<string>();
+  const [income, setIncome] = useState<string>();
+  const [firstName, setFirstName] = useState<string>();
+  const [lastName, setLastName] = useState<string>();
+  const [email, setEmail] = useState<string>();
+  const [loading, setLoading] = useState<boolean>(false);
+  const [ssn, setSSN] = useState<string>();
   const { ...context } = useContext(ResponseContext);
 
   const router = useRouter();

--- a/utils/helper.ts
+++ b/utils/helper.ts
@@ -1,10 +1,16 @@
-export const mask = (value: string) => {
+export const mask = (value?: string) => {
+  if (!value) {
+    return value;
+  }
   const masked = value.slice(0, 7).replace(/[0-9]/g, "*");
   const final = masked + value.slice(7);
   return final;
 };
 
-export const format = (value: string) => {
+export const format = (value?: string) => {
+  if (!value) {
+    return value;
+  }
   value = value.slice(0, 11).replace(/-/g, "");
   let result = "";
   if (value.length <= 3) {


### PR DESCRIPTION
We're seeing a but that is resulting in Prove prefill data requests not including all prefill fields. This appears to be related to the quickstart-app submitting unfilled PII fields as empty strings in the journey application creation payload. This PR defaults those fields to undefined.